### PR TITLE
Fix assigning to null property

### DIFF
--- a/src/Frontend/Form.php
+++ b/src/Frontend/Form.php
@@ -34,6 +34,11 @@ class Form extends ContaoForm
 
             $key                  = substr($key, 16);
             $this->$key           = $value;
+
+            if (null === $this->objModel) {
+                continue;
+            }
+
             $this->objModel->$key = $value;
         }
     }


### PR DESCRIPTION
### Description

Basically fixes an assignment on a null property (that would have been detected by Psalm if not suppressed 😁 )

A client of ours does have a lot of content managers and sometimes it may lead to recreating forms and deleting the other one which will end up in:
<img width="328" height="143" alt="image" src="https://github.com/user-attachments/assets/f1e62fbf-9bdb-4384-86d2-6693b12d49c5" />

This at least fixes an error of assigning values to a null property and makes sure that the following error does not happen, thus throwing an error in the frontend.
```Attempt to assign property "recipient" on null```